### PR TITLE
Better error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/core",
-  "version": "0.5.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -120,6 +120,11 @@
         "lodash": "^4.17.5",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@curveball/http-errors": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@curveball/http-errors/-/http-errors-0.3.0.tgz",
+      "integrity": "sha512-sCx/u8xFxlp/6tbhgCYXJDNLtUbxx3OYE5+jITyTiJhLCTopU5akF2eYlrwgxGtEi+tB8/JlCz0322YV4L6Daw=="
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     ]
   },
   "dependencies": {
+    "@curveball/http-errors": "^0.3.0",
     "accepts": "^1.3.5",
     "raw-body": "^2.3.3"
   },

--- a/src/middleware/not-found.ts
+++ b/src/middleware/not-found.ts
@@ -1,0 +1,39 @@
+import { HttpProblem } from '@curveball/http-errors';
+import Context from '../context';
+
+/**
+ * This middleware simply triggers a 'NotFound' error.
+ *
+ * This is a utility middleware that's automatically added to the middleware
+ * stack to be 'last'.
+ *
+ * The purpose of this mw is that if no other middlewares did anything to
+ * handle a request, we automatically respond with a 404.
+ */
+
+class NoHandler extends Error implements HttpProblem {
+
+  detail: string;
+  httpStatus: number;
+  instance: null;
+  title: string;
+  type: string;
+
+  constructor() {
+
+    super();
+    this.type = 'https://curveballjs.org/errors/no-handler';
+    this.title = 'No handler for this request';
+    this.detail = 'This server doesn\'t know what to do with your request. Did you make a typo?';
+    this.message = this.title;
+    this.httpStatus = 404;
+
+  }
+
+}
+
+export default function mw(ctx: Context) {
+
+  throw new NoHandler();
+
+}

--- a/test/application.ts
+++ b/test/application.ts
@@ -120,7 +120,7 @@ describe('Application', () => {
     const response = await fetch('http://localhost:5555');
     const body = await response.text();
 
-    expect(body).to.equal('Internal Server Error');
+    expect(body).to.include(': 500');
     expect(response.headers.get('server')).to.equal('curveball/' + require('../package.json').version);
     expect(response.status).to.equal(500);
 
@@ -228,7 +228,7 @@ describe('Application', () => {
 
       const response = await fetch('http://localhost:5555');
       const body = await response.text();
-      expect(body).to.equal('Internal Server Error');
+      expect(body).to.include(': 500');
 
       server.close();
 


### PR DESCRIPTION
The curveballjs/http-errors package is now used for a few things:

1. Instead of just setting a `404` status when no middleware did anything, we now throw an Error.
2. If any thrown errors implement `HttpError`, we will respect the `httpStatus` property.
3. Slightly better error messaging.

Fixes #92 